### PR TITLE
3: upgraded from POI 4.0 to 5.0. getCellTypeEnum was removed in 5.x. …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <gmavenProviderSelection>2.0</gmavenProviderSelection>
         <groovyVersion>2.0.0</groovyVersion>
         <spockVersion>1.0-groovy-2.4</spockVersion>
-        <poi.version>4.0.0</poi.version>
+        <poi.version>5.0.0</poi.version>
         <javaTarget>1.7</javaTarget>
     </properties>
 

--- a/src/main/java/org/jxls/reader/OffsetCellCheckImpl.java
+++ b/src/main/java/org/jxls/reader/OffsetCellCheckImpl.java
@@ -84,9 +84,9 @@ public class OffsetCellCheckImpl implements OffsetCellCheck {
             c.setTime(cell.getDateCellValue());
             value = c;
         } else if (obj instanceof Boolean) {
-            if (cell.getCellTypeEnum() == CellType.BOOLEAN) {
+            if (cell.getCellType() == CellType.BOOLEAN) {
                 value = (cell.getBooleanCellValue()) ? Boolean.TRUE : Boolean.FALSE;
-            } else if (cell.getCellTypeEnum() == CellType.STRING) {
+            } else if (cell.getCellType() == CellType.STRING) {
                 value = Boolean.valueOf(cell.getRichStringCellValue().getString());
             } else {
                 value = Boolean.FALSE;
@@ -97,7 +97,7 @@ public class OffsetCellCheckImpl implements OffsetCellCheck {
 
     private String readStringValue(Cell cell) {
         String value = null;
-        switch (cell.getCellTypeEnum()) {
+        switch (cell.getCellType()) {
             case STRING:
                 value = cell.getRichStringCellValue().getString().trim();
                 break;

--- a/src/main/java/org/jxls/reader/OffsetRowCheckImpl.java
+++ b/src/main/java/org/jxls/reader/OffsetRowCheckImpl.java
@@ -109,7 +109,7 @@ public class OffsetRowCheckImpl implements OffsetRowCheck {
         if( cell == null ){
             return true;
         }
-        switch( cell.getCellTypeEnum() ){
+        switch( cell.getCellType() ){
             case BLANK:
                 return true;
             case STRING:

--- a/src/main/java/org/jxls/reader/SimpleBlockReaderImpl.java
+++ b/src/main/java/org/jxls/reader/SimpleBlockReaderImpl.java
@@ -84,7 +84,7 @@ public class SimpleBlockReaderImpl extends BaseBlockReader implements SimpleBloc
     protected String getCellString(Cell cell) {
         String dataString = null;
         if (cell != null) {
-            switch (cell.getCellTypeEnum()) {
+            switch (cell.getCellType()) {
                 case STRING:
                     dataString = cell.getRichStringCellValue().getString();
                     break;


### PR DESCRIPTION
…Usages were replaced with getCellType

Fixes https://github.com/jxlsteam/jxls-reader/issues/3